### PR TITLE
[#6] 백엔드 Api 주소 변경으로 인한 수정

### DIFF
--- a/mocks/handlers.ts
+++ b/mocks/handlers.ts
@@ -488,7 +488,7 @@ export const handlers = [
     }
   }),
 
-  rest.patch('http://localhost:3000/reviewers/:reviewerId/reviews/:reviewId/status', (req, res, ctx) => {
+  rest.patch('http://localhost:3000/reviewers/:reviewerId/reviews/:reviewId/status-accepted', (req, res, ctx) => {
     return res(ctx.status(204));
   }),
 

--- a/pages/api/inquire.ts
+++ b/pages/api/inquire.ts
@@ -19,7 +19,7 @@ export const getReviewDetailInfo = async ({ reviewerId, reviewId }: IReviewDetai
 };
 
 export const acceptReview = async ({ reviewerId, reviewId }: IReviewDetailInfoApiPropsType) => {
-  await instance.patch(`/reviewers/${reviewerId}/reviews/${reviewId}/status`, null, { withCredentials: true });
+  await instance.patch(`/reviewers/${reviewerId}/reviews/${reviewId}/status-accepted`, null, { withCredentials: true });
 };
 
 export const refuseReview = async ({ reviewerId, reviewId }: IReviewDetailInfoApiPropsType) => {


### PR DESCRIPTION
## 상세 내용
- 백엔드 api 주소 변경으로 인한 msw, 비동기 요청 주소 수정


## 주의 사항

- 저희가 목업 데이터 라이브러리를 사용하고 있어서 변경을 함에 있어서 큰 의미는 없지만 백엔드에서 목적에 맞게 Api 수정을 했기 때문에 그에 맞춰서 이슈를 통해서 Api 수정을 했습니다