### PR TITLE
[#27] SSR 후 안티 패턴 제거

### DIFF
--- a/components/InduceLogin/InduceBox.tsx
+++ b/components/InduceLogin/InduceBox.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/router';
 import { getAccessTokenInStorage } from '../../utils/authLogic';
 
 function InduceBox() {
-  const loginUri = `https://github.com/login/oauth/authorize?client_id=5b4fae5a4ea125933cd8&scope=repo:status read:repo_hook user:email&redirect_uri=http://13.124.78.119:80/githubLogin`;
+  const loginUri = `https://github.com/login/oauth/authorize?client_id=${process.env.NEXT_PUBLIC_CLIENT_ID}&scope=repo:status read:repo_hook user:email&redirect_uri=${process.env.NEXT_PUBLIC_FRONT_REDIRECT_URI}`;
 
   const logInHandler = () => {
     window.location.href = loginUri;

--- a/components/Main/FilterCategory.tsx
+++ b/components/Main/FilterCategory.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import clsx from 'clsx';
 import { IFilterCategoryPropsType, ICategoryType, ITagType } from './mainType';
 import CategoryTagBox from './CategoryTagBox';
@@ -15,10 +15,6 @@ function FilterCategory({ setCategory, categories, setSelectedTags, selectedTags
     });
     return filterData[0].tags;
   };
-
-  useEffect(() => {
-    setCategory(categories[0]);
-  }, []);
 
   return (
     <>

--- a/components/Main/Template.tsx
+++ b/components/Main/Template.tsx
@@ -5,7 +5,7 @@ import useSetLocalPath from '../../useHooks/useSetLocalPath';
 import { ITagType, ICategoryType, ICategoriesType } from './mainType';
 
 function Template({ categories }: ICategoriesType) {
-  const [category, setCategory] = useState<ICategoryType | undefined>();
+  const [category, setCategory] = useState<ICategoryType>(categories[0]);
   const [selectedTags, setSelectedTags] = useState<ITagType[]>([]);
 
   useSetLocalPath();

--- a/components/Main/mainType.ts
+++ b/components/Main/mainType.ts
@@ -51,7 +51,7 @@ export interface IReviewersRequestType {
 }
 
 export interface IFilterCategoryPropsType extends ICategoriesType {
-  setCategory: React.Dispatch<React.SetStateAction<ICategoryType | undefined>>;
+  setCategory: React.Dispatch<React.SetStateAction<ICategoryType>>;
   setSelectedTags: React.Dispatch<React.SetStateAction<ITagType[]>>;
   selectedTags: ITagType[];
 }

--- a/mocks/handlers.ts
+++ b/mocks/handlers.ts
@@ -79,7 +79,7 @@ export const handlers = [
       ctx.json({
         username: username,
         email: email,
-        imageUrl: 'image',
+        imageUrl: 'https://upload.wikimedia.org/wikipedia/ko/thumb/2/24/Lenna.png/440px-Lenna.png',
         profileUrl: 'https://github@url.com/kukus',
         isReviewer: false,
       }),

--- a/mocks/index.ts
+++ b/mocks/index.ts
@@ -1,12 +1,12 @@
-// async function initMocks() {
-//   if (typeof window === 'undefined') {
-//     const { server } = await require('./server');
-//     server.listen();
-//   } else {
-//     const { worker } = await require('./browser');
-//     worker.start();
-//   }
-// }
+async function initMocks() {
+  if (typeof window === 'undefined') {
+    const { server } = await require('./server');
+    server.listen();
+  } else {
+    const { worker } = await require('./browser');
+    worker.start();
+  }
+}
 
-// initMocks();
+initMocks();
 export {};

--- a/next.config.js
+++ b/next.config.js
@@ -2,7 +2,7 @@
 const nextConfig = {
   reactStrictMode: false,
   images: {
-    domains: ['avatars.githubusercontent.com'],
+    domains: ['avatars.githubusercontent.com', 'upload.wikimedia.org'],
   },
 };
 

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -11,7 +11,7 @@ import CarouselSwiper from '../components/Commons/CarouselSwiper';
 import Head from 'next/head';
 
 if (process.env.NEXT_PUBLIC_API_MOCKING === 'enabled') {
-  // require('../mocks');
+  require('../mocks');
 }
 
 RecoilEnv.RECOIL_DUPLICATE_ATOM_KEY_CHECKING_ENABLED = false;

--- a/pages/api/core/index.ts
+++ b/pages/api/core/index.ts
@@ -8,7 +8,7 @@ import {
 } from '../../../utils/authLogic';
 
 const instance: AxiosInstance = axios.create({
-  baseURL: `http://54.180.210.74:8080`,
+  baseURL: `http://localhost:3000`, //http://54.180.210.74:8080
   headers: {
     'Content-Type': 'application/json',
   },

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,8 +2,8 @@ import { GetServerSideProps } from 'next';
 import Template from '../components/Main/Template';
 import { ICategoriesType } from '../components/Main/mainType';
 import { getCategories } from './api/main';
-// import { setupServer } from 'msw/node';
-// import { handlers } from '../mocks/handlers';
+import { setupServer } from 'msw/node';
+import { handlers } from '../mocks/handlers';
 import HeadHoc from '../components/Commons/HeadHoc';
 
 const Home = ({ categories }: ICategoriesType) => {
@@ -18,7 +18,7 @@ const Home = ({ categories }: ICategoriesType) => {
 
 export const getServerSideProps: GetServerSideProps = async () => {
   if (process.env.NEXT_PUBLIC_API_MOCKING === 'enabled') {
-    // setupServer(...handlers);
+    setupServer(...handlers);
   }
   const response = await getCategories();
   const categories = response.data.categories;


### PR DESCRIPTION
## 상세 내용
- ssr 이후 불필요한 useEffect를 통한 초기 데이터를 useState에 넣어주는 불필요한 과정 제거했습니다.
- 개발 환경과 배포 환경을 구분하기 위해 환경변수를 통해 다시 나누어 주었습니다.
- msw를 이용함에 따라 제거했던 코드들 다시 올려놨습니다.
- msw의 데이터 타입을 제대로 추가해놨습니다.


## 주의 사항
- 이전 배포 과정에서 있었던 ec2 서버에 env를 이용하려 했던 과정에서 제 실수가 있어서 오류가 났었던 것 같습니다.
- 그래서 환경 변수를 통해서 접근하는 것이 개발환경과 배포 환경을 나눌 수 있는 방법 중 하나가 될 것 같아서 현재 환경 변수를 통해 백엔드 주소 / github oauth client id, github oauth redirect 주소 등을 환경변수로 추가해놨습니다.

<br/>
