### PR TITLE
[#37] 리뷰어 상세 정보 모달 구현

### DIFF
--- a/components/Commons/StarRate/StarRate.tsx
+++ b/components/Commons/StarRate/StarRate.tsx
@@ -26,7 +26,9 @@ function StarRate({ rateValue, setRate, readOnly = false }: IStarRatingPropsType
     if (readOnly) return false;
 
     setIsHovered(false);
-    setRate(calculateRating(e));
+    if (setRate) {
+      setRate(calculateRating(e));
+    }
   };
 
   const starMouseMoveHandler = (e: MouseEvent<HTMLDivElement, globalThis.MouseEvent>) => {

--- a/components/Commons/StarRate/starRateType.ts
+++ b/components/Commons/StarRate/starRateType.ts
@@ -1,5 +1,5 @@
 export interface IStarRatingPropsType {
   rateValue: number;
-  setRate: (num: number) => void;
+  setRate?: (num: number) => void;
   readOnly: boolean;
 }

--- a/components/Main/ReviewerCard.tsx
+++ b/components/Main/ReviewerCard.tsx
@@ -12,7 +12,7 @@ function ReviewerCard({ reviewerProps }: { reviewerProps: IReviewerType }) {
   return (
     <>
       <article
-        className="px-3 py-3 transition-transform ease-in-out border-2 shadow-md flex-cc rounded-radius-m border-neutral300 hover:border-neutral400 hover:scale-105"
+        className="px-3 py-3 transition-transform ease-in-out border-2 shadow-md cursor-pointer flex-cc rounded-radius-m border-neutral300 hover:border-neutral400 hover:scale-105"
         onClick={openModalHandler}>
         <div className="flex flex-col wh-f">
           <p className="w-full line-clamp-3 overflow-ellipsis whitespace-normal min-h-[3rem] leading-4 mb-1">

--- a/components/Main/ReviewerCard.tsx
+++ b/components/Main/ReviewerCard.tsx
@@ -1,54 +1,53 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Image from 'next/image';
 import { IReviewerType } from './mainType';
-import Link from 'next/link';
+import ReviewerModal from '../ReviewerModal/ReviewerModal';
 
 function ReviewerCard({ reviewerProps }: { reviewerProps: IReviewerType }) {
-  return (
-    <article className="px-3 py-3 transition-transform ease-in-out border-2 shadow-md flex-cc rounded-radius-m border-neutral300 hover:border-neutral400 hover:scale-105">
-      <div className="flex flex-col wh-f">
-        <p className="w-full line-clamp-3 overflow-ellipsis whitespace-normal min-h-[3rem] leading-4 mb-1">
-          {reviewerProps.introduction}
-        </p>
-        <div className="flex flex-col text-neutral500">
-          <div>
-            분야 : <strong>{reviewerProps.job}</strong>
-          </div>
-          <div>
-            경력 : <strong>{reviewerProps.career}</strong>
-          </div>
-          <div>
-            github : <strong>{reviewerProps.profileUrl}</strong>
-          </div>
-          <div>
-            tech : <strong>{reviewerProps.techStack.map((item) => item.name).join(', ')}</strong>
-          </div>
-        </div>
+  const [modal, setModal] = useState<boolean>(false);
 
-        <div className="flex justify-between w-full mt-3">
-          <figure className="flex-cc">
-            <Image
-              src={reviewerProps.imageUrl}
-              alt="img"
-              width={30}
-              height={30}
-              className="rounded-radius-50% mr-3"></Image>
-            <figcaption className="text-black">{reviewerProps.username}</figcaption>
-          </figure>
-          <Link
-            href={{
-              pathname: '/register',
-              query: {
-                reviewerId: reviewerProps.id,
-                username: reviewerProps.username,
-              },
-            }}
-            className="px-4 py-2 font-bold bg-gray200 text-c-black rounded-radius-s">
-            리뷰요청
-          </Link>
+  const openModalHandler = () => {
+    setModal((prev) => !prev);
+  };
+  return (
+    <>
+      <article
+        className="px-3 py-3 transition-transform ease-in-out border-2 shadow-md flex-cc rounded-radius-m border-neutral300 hover:border-neutral400 hover:scale-105"
+        onClick={openModalHandler}>
+        <div className="flex flex-col wh-f">
+          <p className="w-full line-clamp-3 overflow-ellipsis whitespace-normal min-h-[3rem] leading-4 mb-1">
+            {reviewerProps.introduction}
+          </p>
+          <div className="flex flex-col text-neutral500">
+            <div>
+              개발 분야 : <strong>{reviewerProps.job}</strong>
+            </div>
+            <div>
+              개발 경력 : <strong>{reviewerProps.career}</strong>
+            </div>
+            <div>
+              기술 스택 : <strong>{reviewerProps.techStack.map((item) => item.name).join(', ')}</strong>
+            </div>
+            <div>
+              깃허브 : <strong>{reviewerProps.profileUrl}</strong>
+            </div>
+          </div>
+
+          <div className="flex justify-between w-full mt-3">
+            <figure className="flex-cc">
+              <Image
+                src={reviewerProps.imageUrl}
+                alt="img"
+                width={30}
+                height={30}
+                className="rounded-radius-50% mr-3"></Image>
+              <figcaption className="text-black">{reviewerProps.username}</figcaption>
+            </figure>
+          </div>
         </div>
-      </div>
-    </article>
+      </article>
+      {modal && <ReviewerModal id={reviewerProps.id} closeModal={setModal} />}
+    </>
   );
 }
 

--- a/components/ReviewerModal/ReviewPaginationButton.tsx
+++ b/components/ReviewerModal/ReviewPaginationButton.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { IReviewerPaginationButtonType } from './reviewerModalType';
+
+function ReviewPaginationButton({ handler, children }: IReviewerPaginationButtonType) {
+  return (
+    <button
+      className="flex items-center px-3 py-2 font-medium text-gray-900 transition-colors bg-white border rounded select-none hover:border-blue-600 hover:bg-black hover:text-white"
+      onClick={handler}>
+      {children}
+    </button>
+  );
+}
+
+export default ReviewPaginationButton;

--- a/components/ReviewerModal/ReviewPaginationButton.tsx
+++ b/components/ReviewerModal/ReviewPaginationButton.tsx
@@ -1,11 +1,11 @@
-import React from 'react';
-import { IReviewerPaginationButtonType } from './reviewerModalType';
+import React, { ComponentProps } from 'react';
+import { StrictPropsWithChildren } from '../Commons/commonsType';
 
-function ReviewPaginationButton({ handler, children }: IReviewerPaginationButtonType) {
+function ReviewPaginationButton({ onClick, children }: StrictPropsWithChildren<ComponentProps<'button'>>) {
   return (
     <button
       className="flex items-center px-3 py-2 font-medium text-gray-900 transition-colors bg-white border rounded select-none hover:border-blue-600 hover:bg-black hover:text-white"
-      onClick={handler}>
+      onClick={onClick}>
       {children}
     </button>
   );

--- a/components/ReviewerModal/ReviewerIntro.tsx
+++ b/components/ReviewerModal/ReviewerIntro.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import Image from 'next/image';
+import { IReviewerModalResponseType } from './reviewerModalType';
+
+function ReviewerIntro({ reviewerDetail }: { reviewerDetail: IReviewerModalResponseType }) {
+  return (
+    <div>
+      <div className="flex justify-between">
+        <div className="flex mb-6">
+          <Image
+            src={reviewerDetail.imageUrl}
+            width={40}
+            height={40}
+            alt="registerImage"
+            className="w-6 h-6 rounded-radius-50%"
+          />
+          <span className="ml-2">{reviewerDetail.username}</span>
+        </div>
+        <span>{reviewerDetail.score}</span>
+      </div>
+      <div className="mb-6">
+        <p>{reviewerDetail.introduction}</p>
+      </div>
+      <div className="pb-6 border-b">
+        <p>개발 분야 : {reviewerDetail.job}</p>
+        <p>기술 스택 : {reviewerDetail.techStack.map((item) => item.name).join(', ')}</p>
+        <p>개발 경력 : {reviewerDetail.career}</p>
+        <p>깃허브 : {reviewerDetail.profileUrl}</p>
+      </div>
+    </div>
+  );
+}
+
+export default ReviewerIntro;

--- a/components/ReviewerModal/ReviewerIntro.tsx
+++ b/components/ReviewerModal/ReviewerIntro.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Image from 'next/image';
 import { IReviewerModalResponseType } from './reviewerModalType';
+import StarRate from '../Commons/StarRate/StarRate';
 
 function ReviewerIntro({ reviewerDetail }: { reviewerDetail: IReviewerModalResponseType }) {
   return (
@@ -16,7 +17,9 @@ function ReviewerIntro({ reviewerDetail }: { reviewerDetail: IReviewerModalRespo
           />
           <span className="ml-2">{reviewerDetail.username}</span>
         </div>
-        <span>{reviewerDetail.score}</span>
+        <span>
+          <StarRate rateValue={reviewerDetail.score} readOnly={true} />
+        </span>
       </div>
       <div className="mb-6">
         <p>{reviewerDetail.introduction}</p>

--- a/components/ReviewerModal/ReviewerModal.tsx
+++ b/components/ReviewerModal/ReviewerModal.tsx
@@ -24,7 +24,12 @@ function ReviewerModal({ id, closeModal }: IReviewerModalType) {
   };
 
   const nextHandler = () => {
-    setPage((prev) => prev + 1);
+    setPage((prev) => {
+      if (reviewerScoreList?.hasNext) {
+        return prev + 1;
+      }
+      return prev;
+    });
   };
 
   const closeModalHandler = () => {

--- a/components/ReviewerModal/ReviewerModal.tsx
+++ b/components/ReviewerModal/ReviewerModal.tsx
@@ -60,8 +60,8 @@ function ReviewerModal({ id, closeModal }: IReviewerModalType) {
               {reviewerScoreList && <ReviewerScoreListBox reviewerScoreList={reviewerScoreList} />}
 
               <nav className="flex justify-center w-full gap-5">
-                <ReviewPaginationButton handler={prevHandler}>⪻</ReviewPaginationButton>
-                <ReviewPaginationButton handler={nextHandler}>⪼</ReviewPaginationButton>
+                <ReviewPaginationButton onClick={prevHandler}>⪻</ReviewPaginationButton>
+                <ReviewPaginationButton onClick={nextHandler}>⪼</ReviewPaginationButton>
               </nav>
               <Link
                 href={{

--- a/components/ReviewerModal/ReviewerModal.tsx
+++ b/components/ReviewerModal/ReviewerModal.tsx
@@ -1,0 +1,85 @@
+import React, { useState } from 'react';
+import { useGetReviewerDetailInfo, useGetReviewerScoreList } from './queries/getReviewerModalQuery';
+import cancel from '../../styles/images/cancel.svg';
+import Image from 'next/image';
+import Link from 'next/link';
+import ReviewPaginationButton from './ReviewPaginationButton';
+import ReviewerScoreListBox from './ReviewerScoreListBox';
+import ReviewerIntro from './ReviewerIntro';
+import { IReviewerModalType } from './reviewerModalType';
+
+function ReviewerModal({ id, closeModal }: IReviewerModalType) {
+  const [page, setPage] = useState<number>(0);
+
+  const { data: reviewerDetail } = useGetReviewerDetailInfo({ reviewerId: id });
+  const { data: reviewerScoreList } = useGetReviewerScoreList({ reviewerId: id, page });
+
+  const prevHandler = () => {
+    setPage((prev) => {
+      if (prev > 0) {
+        return prev - 1;
+      }
+      return prev;
+    });
+  };
+
+  const nextHandler = () => {
+    setPage((prev) => prev + 1);
+  };
+
+  const closeModalHandler = () => {
+    closeModal((prev) => !prev);
+  };
+
+  return (
+    <div className="fixed inset-0 z-10 flex-cc-col">
+      <div className="modal_bg" onClick={closeModalHandler} />
+      <section
+        className="z-20 bg-c-white flex relative flex-col p-7 rounded-radius-m h-[44rem] min-w-[36rem] w-[36rem]
+                  msm:w-full msm:min-w-0 msm:fixed msm:bottom-0 msm:rounded-b-radius-none msm:animate-up-animation">
+        <div className="flex flex-col wh-f">
+          <div className="flex justify-between">
+            <div>
+              <strong className="text-lg">리뷰어 소개</strong>
+            </div>
+            <div className="flex">
+              <Image
+                src={cancel}
+                alt="cancel"
+                width="15"
+                height="15"
+                className="cursor-pointer"
+                onClick={closeModalHandler}
+              />
+            </div>
+          </div>
+          {reviewerDetail && (
+            <div className="flex flex-col flex-1 h-full mt-6 space-y-6 overflow-y-auto">
+              <ReviewerIntro reviewerDetail={reviewerDetail} />
+
+              {reviewerScoreList && <ReviewerScoreListBox reviewerScoreList={reviewerScoreList} />}
+
+              <nav className="flex justify-center w-full gap-5">
+                <ReviewPaginationButton handler={prevHandler}>⪻</ReviewPaginationButton>
+                <ReviewPaginationButton handler={nextHandler}>⪼</ReviewPaginationButton>
+              </nav>
+              <Link
+                href={{
+                  pathname: '/register',
+                  query: {
+                    reviewerId: reviewerDetail.id,
+                    username: reviewerDetail.username,
+                  },
+                }}
+                className="px-4 py-2 font-bold text-center bg-gray200 text-c-black rounded-radius-s hover:bg-black hover:text-c-white">
+                리뷰요청
+              </Link>
+            </div>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+export default ReviewerModal;

--- a/components/ReviewerModal/ReviewerModal.tsx
+++ b/components/ReviewerModal/ReviewerModal.tsx
@@ -40,7 +40,7 @@ function ReviewerModal({ id, closeModal }: IReviewerModalType) {
     <div className="fixed inset-0 z-10 flex-cc-col">
       <div className="modal_bg" onClick={closeModalHandler} />
       <section
-        className="z-20 bg-c-white flex relative flex-col p-7 rounded-radius-m h-[44rem] min-w-[36rem] w-[36rem]
+        className="z-20 bg-c-white flex relative flex-col p-7 rounded-radius-m min-w-[36rem] w-[36rem]
                   msm:w-full msm:min-w-0 msm:fixed msm:bottom-0 msm:rounded-b-radius-none msm:animate-up-animation">
         <div className="flex flex-col wh-f">
           <div className="flex justify-between">
@@ -65,8 +65,8 @@ function ReviewerModal({ id, closeModal }: IReviewerModalType) {
               {reviewerScoreList && <ReviewerScoreListBox reviewerScoreList={reviewerScoreList} />}
 
               <nav className="flex justify-center w-full gap-5">
-                <ReviewPaginationButton onClick={prevHandler}>⪻</ReviewPaginationButton>
-                <ReviewPaginationButton onClick={nextHandler}>⪼</ReviewPaginationButton>
+                <ReviewPaginationButton onClick={prevHandler}>{'<'}</ReviewPaginationButton>
+                <ReviewPaginationButton onClick={nextHandler}>{'>'}</ReviewPaginationButton>
               </nav>
               <Link
                 href={{

--- a/components/ReviewerModal/ReviewerScoreListBox.tsx
+++ b/components/ReviewerModal/ReviewerScoreListBox.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import Image from 'next/image';
+import { IReviewerScoreListResponseType } from './reviewerModalType';
+
+function ReviewerScoreListBox({ reviewerScoreList }: { reviewerScoreList: IReviewerScoreListResponseType }) {
+  return (
+    <div>
+      <div>
+        <strong className="text-lg">리뷰 후기</strong>
+      </div>
+      <div className="flex flex-col w-full">
+        {reviewerScoreList?.evaluations.map((item) => (
+          <div className="flex flex-col w-full mb-2 border-b" key={item.id}>
+            <div className="flex justify-between">
+              <figure className="flex">
+                <Image
+                  src={item.imageUrl}
+                  alt="userImg"
+                  width={25}
+                  height={25}
+                  className="rounded-radius-50% mr-3 mb-2"
+                />
+                <figcaption className="text-black">{item.username}</figcaption>
+              </figure>
+              {item.score}
+            </div>
+
+            <p>{item.content}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default ReviewerScoreListBox;

--- a/components/ReviewerModal/queries/getReviewerModalQuery.tsx
+++ b/components/ReviewerModal/queries/getReviewerModalQuery.tsx
@@ -12,15 +12,11 @@ export function useGetReviewerDetailInfo({ reviewerId }: { reviewerId: number })
 }
 
 export function useGetReviewerScoreList({ reviewerId, page }: { reviewerId: number; page: number }) {
-  return useQuery(
-    ['reviewer', 'score', reviewerId, page],
-    () => getReviewerScoreList({ size: 3, page, reviewerId: reviewerId }),
-    {
-      retry: false,
-      staleTime: 1000 * 20,
-      onError: () => {
-        toast.error('리뷰어 평가 점수 요청에 실패했습니다.');
-      },
+  return useQuery(['reviewer', 'score', reviewerId, page], () => getReviewerScoreList({ size: 3, page, reviewerId }), {
+    retry: false,
+    staleTime: 1000 * 20,
+    onError: () => {
+      toast.error('리뷰어 평가 점수 요청에 실패했습니다.');
     },
-  );
+  });
 }

--- a/components/ReviewerModal/queries/getReviewerModalQuery.tsx
+++ b/components/ReviewerModal/queries/getReviewerModalQuery.tsx
@@ -1,0 +1,26 @@
+import { useQuery } from '@tanstack/react-query';
+import toast from 'react-hot-toast';
+import { getReviewerDetail, getReviewerScoreList } from '../../../pages/api/reviewerDetail';
+
+export const ROLE = 'REVIEWS';
+
+export function useGetReviewerDetailInfo({ reviewerId }: { reviewerId: number }) {
+  return useQuery(['getReviewerDetailInfo', reviewerId], () => getReviewerDetail({ reviewerId: reviewerId }), {
+    retry: false,
+    staleTime: 1000 * 20,
+  });
+}
+
+export function useGetReviewerScoreList({ reviewerId, page }: { reviewerId: number; page: number }) {
+  return useQuery(
+    ['reviewer', 'score', reviewerId, page],
+    () => getReviewerScoreList({ size: 3, page, reviewerId: reviewerId }),
+    {
+      retry: false,
+      staleTime: 1000 * 20,
+      onError: () => {
+        toast.error('리뷰어 평가 점수 요청에 실패했습니다.');
+      },
+    },
+  );
+}

--- a/components/ReviewerModal/reviewerModalType.ts
+++ b/components/ReviewerModal/reviewerModalType.ts
@@ -1,0 +1,32 @@
+import { IReviewerType } from '../Main/mainType';
+
+export interface IReviewerModalResponseType extends IReviewerType {
+  score: number;
+}
+
+export interface IReviewerScoreListType {
+  page: number;
+  size: number;
+}
+
+export interface IReviewerScoreListResponseType {
+  evaluations: IEvaluationsType[];
+}
+
+export interface IEvaluationsType {
+  id: number;
+  username: string;
+  imageUrl: string;
+  score: number;
+  content: string;
+}
+
+export interface IReviewerModalType {
+  id: number;
+  closeModal: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+export interface IReviewerPaginationButtonType {
+  handler: React.MouseEventHandler<HTMLButtonElement>;
+  children: React.ReactNode;
+}

--- a/components/ReviewerModal/reviewerModalType.ts
+++ b/components/ReviewerModal/reviewerModalType.ts
@@ -1,4 +1,4 @@
-import { IReviewerType } from '../Main/mainType';
+import { IReviewersType, IReviewerType } from '../Main/mainType';
 
 export interface IReviewerModalResponseType extends IReviewerType {
   score: number;
@@ -7,9 +7,10 @@ export interface IReviewerModalResponseType extends IReviewerType {
 export interface IReviewerScoreListType {
   page: number;
   size: number;
+  reviewerId: number;
 }
 
-export interface IReviewerScoreListResponseType {
+export interface IReviewerScoreListResponseType extends Pick<IReviewersType, 'hasNext'> {
   evaluations: IEvaluationsType[];
 }
 

--- a/components/ReviewerModal/reviewerModalType.ts
+++ b/components/ReviewerModal/reviewerModalType.ts
@@ -25,8 +25,3 @@ export interface IReviewerModalType {
   id: number;
   closeModal: React.Dispatch<React.SetStateAction<boolean>>;
 }
-
-export interface IReviewerPaginationButtonType {
-  handler: React.MouseEventHandler<HTMLButtonElement>;
-  children: React.ReactNode;
-}

--- a/mocks/handlers.ts
+++ b/mocks/handlers.ts
@@ -139,7 +139,7 @@ export const handlers = [
     return res(ctx.status(200), ctx.json(reviewerDetailInfoData));
   }),
 
-  rest.get('http://localhost:3000/reviewers/:reviewerId/evaluations', (req, res, ctx) => {
+  rest.get('http://localhost:3000/evaluations', (req, res, ctx) => {
     return res(ctx.status(200), ctx.json(reviewerScoreListData));
   }),
 ];

--- a/mocks/handlers.ts
+++ b/mocks/handlers.ts
@@ -7,6 +7,8 @@ import {
   reviewersData,
   reviewsData,
   userData,
+  reviewerDetailInfoData,
+  reviewerScoreListData,
 } from './mockApiData';
 
 export const handlers = [
@@ -131,5 +133,13 @@ export const handlers = [
 
   rest.patch('http://localhost:3000/reviewers/:reviewerId/reviews/:reviewId/status-approved', (req, res, ctx) => {
     return res(ctx.status(204));
+  }),
+
+  rest.get('http://localhost:3000/reviewers/:reviewerId', (req, res, ctx) => {
+    return res(ctx.status(200), ctx.json(reviewerDetailInfoData));
+  }),
+
+  rest.get('http://localhost:3000/reviewers/:reviewerId/evaluations', (req, res, ctx) => {
+    return res(ctx.status(200), ctx.json(reviewerScoreListData));
   }),
 ];

--- a/mocks/mockApiData.ts
+++ b/mocks/mockApiData.ts
@@ -392,6 +392,7 @@ export const reviewerDetailInfoData = {
   ],
 };
 
+// get : http://localhost:3000/reviewers/:reviewerId/evaluations
 export const reviewerScoreListData = {
   evaluations: [
     {

--- a/mocks/mockApiData.ts
+++ b/mocks/mockApiData.ts
@@ -392,7 +392,7 @@ export const reviewerDetailInfoData = {
   ],
 };
 
-// get : http://localhost:3000/reviewers/:reviewerId/evaluations
+// get : http://localhost:3000/evaluations
 export const reviewerScoreListData = {
   evaluations: [
     {

--- a/mocks/mockApiData.ts
+++ b/mocks/mockApiData.ts
@@ -368,3 +368,52 @@ export const reviewerDetailInformationData = {
     { id: 4, name: 'View' },
   ],
 };
+
+// get : http://localhost:3000/reviewers/:reviewerId
+export const reviewerDetailInfoData = {
+  id: 1,
+  username: 'nickname',
+  imageUrl: 'https://upload.wikimedia.org/wikipedia/ko/thumb/2/24/Lenna.png/440px-Lenna.png',
+  profileUrl: 'GitHub URL',
+  job: '백엔드',
+  career: '신입(1년 이하)',
+  introduction:
+    '안녕 안녕 안녕 안녕 안녕 안녕 안녕 안녕 안녕 안녕 안녕 안녕 안녕 안녕 안녕 안녕 안녕 안녕 안녕 안녕 안녕 안녕 안녕 안녕 안녕 안녕 안녕 안녕 안녕 안녕 안녕 안녕 안녕 안녕 안녕하세요 안녕',
+  score: 4.5,
+  techStack: [
+    {
+      id: 1,
+      name: 'Java',
+    },
+    {
+      id: 2,
+      name: 'Spring',
+    },
+  ],
+};
+
+export const reviewerScoreListData = {
+  evaluations: [
+    {
+      id: 1,
+      username: '리뷰이1',
+      imageUrl: 'https://upload.wikimedia.org/wikipedia/ko/thumb/2/24/Lenna.png/440px-Lenna.png',
+      score: 4.5,
+      content: '정말 도움이 많이 되었습니다!',
+    },
+    {
+      id: 2,
+      username: '리뷰이2',
+      imageUrl: 'https://upload.wikimedia.org/wikipedia/ko/thumb/2/24/Lenna.png/440px-Lenna.png',
+      score: 5.0,
+      content: '감사합니다~!',
+    },
+    {
+      id: 3,
+      username: '리뷰이3',
+      imageUrl: 'https://upload.wikimedia.org/wikipedia/ko/thumb/2/24/Lenna.png/440px-Lenna.png',
+      score: 4.0,
+      content: '리뷰를 통해서 코드를 개선하게 되었습니다. 감사합니다.',
+    },
+  ],
+};

--- a/pages/api/core/index.ts
+++ b/pages/api/core/index.ts
@@ -8,7 +8,7 @@ import {
 } from '../../../utils/authLogic';
 
 const instance: AxiosInstance = axios.create({
-  baseURL: `http://localhost:3000`, //http://54.180.210.74:8080
+  baseURL: process.env.NEXT_PUBLIC_BACK_API,
   headers: {
     'Content-Type': 'application/json',
   },
@@ -37,7 +37,7 @@ instance.interceptors.response.use(
         deleteAccessTokenInStorage();
         const refreshToken = getRefreshTokenInStorage();
         const refreshResponse = await axios.post(
-          `http://54.180.210.74:8080/auth/refresh`,
+          `${process.env.NEXT_PUBLIC_BACK_API}/auth/refresh`,
           {
             withCredentials: true,
           },

--- a/pages/api/reviewerDetail.ts
+++ b/pages/api/reviewerDetail.ts
@@ -1,0 +1,39 @@
+import {
+  IReviewerModalResponseType,
+  IReviewerScoreListResponseType,
+} from '../../components/ReviewerModal/reviewerModalType';
+import instance from './core';
+
+export const getReviewerDetail = async ({ reviewerId }: { reviewerId: number }) => {
+  try {
+    const reviewerDetailResponse = await instance.get<IReviewerModalResponseType>(`/reviewers/${reviewerId}`);
+    return reviewerDetailResponse.data;
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+export const getReviewerScoreList = async ({
+  reviewerId,
+  size,
+  page,
+}: {
+  reviewerId: number;
+  size: number;
+  page: number;
+}) => {
+  try {
+    const reviewerScoreList = await instance.get<IReviewerScoreListResponseType>(
+      `/reviewers/${reviewerId}/evaluations`,
+      {
+        params: {
+          size: size,
+          page: page,
+        },
+      },
+    );
+    return reviewerScoreList.data;
+  } catch (error) {
+    console.error(error);
+  }
+};

--- a/pages/api/reviewerDetail.ts
+++ b/pages/api/reviewerDetail.ts
@@ -1,6 +1,7 @@
 import {
   IReviewerModalResponseType,
   IReviewerScoreListResponseType,
+  IReviewerScoreListType,
 } from '../../components/ReviewerModal/reviewerModalType';
 import instance from './core';
 
@@ -13,25 +14,15 @@ export const getReviewerDetail = async ({ reviewerId }: { reviewerId: number }) 
   }
 };
 
-export const getReviewerScoreList = async ({
-  reviewerId,
-  size,
-  page,
-}: {
-  reviewerId: number;
-  size: number;
-  page: number;
-}) => {
+export const getReviewerScoreList = async ({ reviewerId, size, page }: IReviewerScoreListType) => {
   try {
-    const reviewerScoreList = await instance.get<IReviewerScoreListResponseType>(
-      `/reviewers/${reviewerId}/evaluations`,
-      {
-        params: {
-          size: size,
-          page: page,
-        },
+    const reviewerScoreList = await instance.get<IReviewerScoreListResponseType>(`/evaluations`, {
+      params: {
+        reviewerId,
+        size: size,
+        page: page,
       },
-    );
+    });
     return reviewerScoreList.data;
   } catch (error) {
     console.error(error);


### PR DESCRIPTION
## 상세 내용
- 리뷰어 상세정보 모달
- 리뷰 후기 페이지네이션 (useQuery 사용)
- 이전 배포 시 api core 부분에서 미처 수정하지 못한 부분 수정
- 메인 페이지의 리뷰어 카드 디자인 수정
<br/>

## 주의 사항
- 별 모양은 다 만들고 보니 전부 들어가도 괜찮을 것 같아서 우선은 점수 자체만 올려놨습니다. 경호님이 올려주시면 그 부분을 사용하려 합니다. 위치만 잡아놨습니다!
- PR 올린 후 명세 수정이 하나 있습니다. (hasNext추가 - 리뷰어 평가 조회 로직에서 다음 페이지로 가는 버튼 클릭시 다음 페이지의 정보가 없다면 조회하지 못하게 수정) 이 부분은 명세 올라오면 수정할 예정입니다.
<br/>
