### PR TITLE
[#49] reactQuery stale-time, invalidateQueries 이슈 수정

### DIFF
--- a/components/ReviewModal/queries/getReviewModalQuery.tsx
+++ b/components/ReviewModal/queries/getReviewModalQuery.tsx
@@ -6,6 +6,5 @@ export function useReviewModalGetQuery({ reviewId, reviewerId }: IReviewDetailIn
   return useQuery<IReviewModalApiDetailType>({
     queryKey: ['modalDetail', reviewId],
     queryFn: () => getReviewDetailInfo({ reviewerId, reviewId }),
-    staleTime: 1000 * 20,
   });
 }

--- a/components/ReviewRate/queries/getReviewRateQuery.tsx
+++ b/components/ReviewRate/queries/getReviewRateQuery.tsx
@@ -33,11 +33,23 @@ export function useReviewRateRegisterMutation({
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: () => postReviewRate({ reviewId, reviewerId, score, content }),
-    onSuccess: () => {
+    onSuccess: async () => {
       toast.success('평가가 반영되었습니다.');
-      queryClient.invalidateQueries(['getReviews', ROLE, 'reviewee']);
-      queryClient.invalidateQueries(['reviewRate', reviewId]);
+      await queryClient.invalidateQueries({
+        queryKey: ['getReviews', ROLE, 'reviewee'],
+        refetchType: 'all',
+      });
+      await queryClient.invalidateQueries({
+        queryKey: ['reviewRate'],
+        refetchType: 'all',
+      });
+      await queryClient.refetchQueries(['reviewRate']);
       closeHandler();
+      //await Promise.all([
+      //
+      //queryClient.invalidateQueries(['reviewRate']),
+
+      //]);
     },
     onError: () => {
       toast.error('에러가 발생했습니다.');


### PR DESCRIPTION
## 상세 내용
- 리뷰 신청 상세 모달에서 react-query의 stale time에 의해서 실시간으로 적용되어야 하는 정보가 보여지지 않는 에러 해결(stale time default 값으로 변경)
- 평가 로직 stale time이 20초로 되어있으며, invalidateQueries를 통해 초기화를 하지만 실제로는 초기화가 되지 않고 이전 데이터를 가져오며 stale time이 지난 후에만 데이터를 받아오는 로직 수정 invalidateQueries의 refetch option을 사용했지만 미해결 상태


